### PR TITLE
Stops people using snipe command unless they are staff

### DIFF
--- a/bot/discord/commands/snipe.js
+++ b/bot/discord/commands/snipe.js
@@ -8,7 +8,7 @@ exports.run = async (client, message, args) => {
         message.channel.send('Check your dms.');
         return;
     }
-
+    if (message.member.roles.cache.find(r => r.id === config.DiscordBot.roles.staff) == null) return message.reply("You seemed to drop the sniper when you tried sniping, please learn how to snipe.");
     let embed3 = new Discord.MessageEmbed().setDescription(`Theres nothing to snipe`)
 
     let snipe = messageSnipes.get(message.channel.id)


### PR DESCRIPTION
This is to stop people ||random|| people from using the command, So only staff can use it