### PR TITLE
fix non-prem using wrong docker image

### DIFF
--- a/createData.js
+++ b/createData.js
@@ -192,7 +192,7 @@ list.aio = (serverName, userID) => ({
     "user": userID,
     "nest": 5,
     "egg": 46,
-    "docker_image": "danielpmc/discordnode8",
+    "docker_image": "danbothosting/aio",
     "startup": "${STARTUP_CMD}",
     "limits": {
         "memory": 0,


### PR DESCRIPTION
this pr fixes non-prem servers using wrong docker image and thus they dont have nodejs16