### PR TITLE
Fix the user is undefined error on the error page.

### DIFF
--- a/views/partials/header.ejs
+++ b/views/partials/header.ejs
@@ -449,6 +449,7 @@
                             <button style="outline: none;" onclick=goto("/cams") class="dropbtn">Server Cams</button>
                         </div>
                     </li>
+                    <% let user = null %>
                     <% if(user) { %>
 
                         <div class="dropdown">
@@ -480,6 +481,7 @@
             </div>
 
             <ul class="navbar-nav">
+                <% let user = null %>
                 <% if(user) { %>
                     <% let Developers = ["137624084572798976"]; %>
                     <% if(Developers.includes(user.id)) { %>


### PR DESCRIPTION
User is undefined because if it’s not passed through, it can’t be seen on the page. Which causes the “error” on the error page.