### PR TITLE
Adding "server list" command to "server" help command

### DIFF
--- a/bot/discord/commands/server/help.js
+++ b/bot/discord/commands/server/help.js
@@ -8,6 +8,7 @@ exports.run = async(client, message, args) => {
             config.DiscordBot.Prefix + 'server status <serverid>` \nLink Domain: `' +
             config.DiscordBot.Prefix + 'server proxy <domainhere> <serveridhere> ` \n Unlink domain: `' +
             config.DiscordBot.Prefix + 'server unproxy <domainhere>` \n Delete server: `' +
-            config.DiscordBot.Prefix + 'server delete <serveridhere>`')
+            config.DiscordBot.Prefix + 'server delete <serveridhere>` \n List servers:' +
+            config.DiscordBot.Prefix + 'server list`' +)
     await message.channel.send(embed)
 }


### PR DESCRIPTION
I saw that it existed the command `DBH!server list` but it wasn't listed when you execute `DBH!server`. 
In this PR I add it into the help file of the server command.