### PR TITLE
To Fix to stop the premium premium count bug

### DIFF
--- a/bot/discord/commands/server/create-donator.js
+++ b/bot/discord/commands/server/create-donator.js
@@ -93,7 +93,7 @@ exports.run = async(client, message, args) => {
         serverCreateSettings_Prem.createServer(types[args[1].toLowerCase()])
             .then(response => {
 
-                userPrem.set(message.author.id + '.used', userP.used + 1);
+                userPrem.add(message.author.id + '.used', 1);
 
                 let embed = new Discord.MessageEmbed()
                     .setColor(`GREEN`)


### PR DESCRIPTION
People gets an incorect server count when they run the server create-donator command because of the delay executed when creating the server. By using the function ".add" from quick.db it will fix the situation. (Because it takes the value in realtime)