### PR TITLE
System Admins only

### DIFF
--- a/bot/discord/commands/staff/sudo.js
+++ b/bot/discord/commands/staff/sudo.js
@@ -1,5 +1,5 @@
 exports.run = async(client, message, args) => {
-    if (!message.member.roles.cache.find(r => r.id === "898041747597295667")) return;
+    if (!message.member.roles.cache.find(r => r.id === "934859709641527318")) return;
 
     if (!args[1]) {
         const userID = sudo.get(message.member.id);


### PR DESCRIPTION
Developers shouldn't be allowed to Sudo it should be only really for "System Admins" or someone besides developers. This is a huge security risk and can lead to abuse since they can give themselves more perms than before with an Admin role.