### PR TITLE
Added dono-create disabled option

### DIFF
--- a/bot/discord/commands/server/create-donator.js
+++ b/bot/discord/commands/server/create-donator.js
@@ -1,7 +1,12 @@
 const serverCreateSettings_Prem = require('../../../../createData_Prem');
 const axios = require('axios');
+const createServerEnabled = false; //false if the feature is disabled and true if enabled
 
 exports.run = async(client, message, args) => {
+    if (createServerEnabled === false) {
+        message.channel.send("❌ This feature is currently disabled. Please **DON'T** create a ticket, ask for help or spam others! This is because me (Dan) disabled it.")
+        return;
+    }
 
     let userP = userPrem.fetch(message.author.id) || {
         used: 0,


### PR DESCRIPTION
So dono members stop retrying to create a new server every 1h. Also you should probably move the variable to a place like a database so you don't have to restart the bot or commit to GitHub every time. You know if i became a dev in your team i could even make a command for this.