### PR TITLE
fix: improper user premium output

### DIFF
--- a/bot/discord/commands/server/redeem.js
+++ b/bot/discord/commands/server/redeem.js
@@ -17,7 +17,7 @@ exports.run = async(client, message, args) => {
         let oldBal = userPrem.get(message.author.id + '.donated') || 0;
 
         let now = Date.now();
-        message.reply(`You have redeemed a code with ${code.balance} premium server(s), you now have ${oldBal + code.balance}!`)
+        message.reply(`You have redeemed a code with ${code.balance} premium server(s), you now have ${Math.floor((oldBal + code.balance) / config.node7.price)}!`);
         client.channels.cache.get('898041841939783732').send('<@' + message.author.id + '>, Redeemed code: ' + args[1] + ' it held ' + code.balance + ' premium servers! *This code was redeemed in ' + humanizeDuration(now - code.createdAt) + '*')
 
         codes.delete(args[1]);


### PR DESCRIPTION
When redeeming the code, it doesn't divide by the price of a single premium server price, which results in a invalid user premium count.