### PR TITLE
feat: poll ping command

### DIFF
--- a/bot/discord/commands/staff/pollping.js
+++ b/bot/discord/commands/staff/pollping.js
@@ -4,6 +4,9 @@ exports.run = (client, message, args) => {
     if (!message.member.roles.cache.find((r) => r.id === "898041747597295667")) return;
     // Check the message is in the #dev-questions channel
     if(message.channel.id !== "1083142107977486389") return message.reply("This command can only be used in <#1083142107977486389>!");
+    // Command can only be used every 30 minutes
+    if(pollPingLastUsed + 1800000 > Date.now()) return message.reply(`This command can only be used every 30 minutes! Cooldown expires <t:${(pollPingLastUsed + 1800000).toString().slice(0, -3)}:R>`)
 
     message.reply("<@&898041781927682090>");
+    global.pollPingLastUsed = Date.now();
 };

--- a/bot/discord/commands/staff/pollping.js
+++ b/bot/discord/commands/staff/pollping.js
@@ -1,0 +1,9 @@
+const Discord = require("discord.js");
+exports.run = (client, message, args) => {
+    // Check if user has the dev role
+    if (!message.member.roles.cache.find((r) => r.id === "898041747597295667")) return;
+    // Check the message is in the #dev-questions channel
+    if(message.channel.id !== "1083142107977486389") return message.reply("This command can only be used in <#1083142107977486389>!");
+
+    message.reply("<@&898041781927682090>");
+};

--- a/bot/discord/commands/staff/pollping.js
+++ b/bot/discord/commands/staff/pollping.js
@@ -4,7 +4,12 @@ exports.run = (client, message, args) => {
     // Check the message is in the #dev-questions channel
     if(message.channel.id !== "1083142107977486389") return message.reply("This command can only be used in <#1083142107977486389>!");
     // Command can only be used every 30 minutes
-    if(pollPingLastUsed + 1800000 > Date.now()) return message.reply(`This command can only be used every 30 minutes! Cooldown expires <t:${(pollPingLastUsed + 1800000).toString().slice(0, -3)}:R>`)
+    if(pollPingLastUsed + 1800000 > Date.now()) {
+        message.reply(
+            `This command can only be used every 30 minutes! Cooldown expires <t:${(pollPingLastUsed + 1800000).toString().slice(0, -3)}:R>`
+        )
+        return;
+    }
 
     message.reply("<@&898041781927682090>");
     global.pollPingLastUsed = Date.now();

--- a/bot/discord/commands/staff/pollping.js
+++ b/bot/discord/commands/staff/pollping.js
@@ -1,4 +1,3 @@
-const Discord = require("discord.js");
 exports.run = (client, message, args) => {
     // Check if user has the dev role
     if (!message.member.roles.cache.find((r) => r.id === "898041747597295667")) return;

--- a/index.js
+++ b/index.js
@@ -57,6 +57,8 @@ global.client = new Discord.Client({
 });
 global.bot = client;
 
+global.pollPingLastUsed = 0;
+
 require("./bot/discord/commands/mute").init(client);
 
 //Event handler


### PR DESCRIPTION
Adds a command which pings the poll ping role which only works in #dev-questions and has a cooldown of 30 minutes to reduce the risk of abuse.

This is useful as developers currently cannot ping the poll ping role in #dev-questions.