### PR TITLE
fix: gmod egg missing variable as of Panel v1.11.7

### DIFF
--- a/create-premium/gmod.js
+++ b/create-premium/gmod.js
@@ -21,6 +21,7 @@ createListPrem.gmod = (serverName, userID) => ({
         GAMEMODE: "sandbox",
         MAX_PLAYERS: "32",
         TICKRATE: "22",
+        LUA_REFRESH: "0"
     },
     feature_limits: {
         databases: 2,


### PR DESCRIPTION
Fixing Gary's Mod egg creation. This was caused by a missing variable that was only required in a recent Pterodactyl panel update.