### PR TITLE
fix: added error handling

### DIFF
--- a/src/commands/server/proxy.js
+++ b/src/commands/server/proxy.js
@@ -178,6 +178,9 @@ exports.run = async (client, message, args) => {
             replyMsg.edit(`Domain found pointing towards ${ProxyLocation.name}...`);
 
             proxyDomain(ProxyLocation, PterodactylServerResponse, replyMsg, args, Token);
+        }).catch(async (Error) => {
+            console.error("[SERVER PROXY - GETTING SERVER]: " + Error);
+            return message.channel.send("An error occurred while fetching your server. Please try again later.");
         });
 
         function proxyDomain(ProxyLocation, response, replyMsg, args, token) {
@@ -329,5 +332,8 @@ exports.run = async (client, message, args) => {
                 await replyMsg.edit(replyMsg.content + "\n\nUnable to delete proxy automatically. You must have a staff member to manually fix this.");
             });
         }
+    }).catch(async (Error) => {
+        console.error("[SERVER PROXY - GETTING USER SERVERS]: " + Error);
+        return message.channel.send("An error occurred while fetching your servers. Please try again later.");
     });
 };

--- a/src/commands/server/unproxy.js
+++ b/src/commands/server/unproxy.js
@@ -184,8 +184,9 @@ exports.run = async (client, message, args) => {
                     });
                 });
             }
-        }).catch(Error => {
+        }).catch(async (Error) => {
             console.error("[PROXY SYSTEM ERROR]: " + Error);
+            await message.reply("[PROXY SYSTEM] An error occurred while trying to unproxy the domain. Please try again later.");
         });
     
     //Domains from old proxies.


### PR DESCRIPTION
Adding some error handling when Panel or Proxies are down. Previously it was expected that proxies were up and online, and therefore there was no testing for this type of behavior.