### PR TITLE
feat: fixing proxying for server responses

### DIFF
--- a/src/commands/server/proxy.js
+++ b/src/commands/server/proxy.js
@@ -199,8 +199,7 @@ exports.run = async (client, message, args) => {
                     forward_scheme: "http",
                     forward_host: response.data.attributes.sftp_details.ip,
                     forward_port:
-                        response.data.attributes.relationships.allocations.data[0].attributes
-                            .port,
+                        response.data.attributes.relationships.allocations.data.find(m => m.attributes.is_default).attributes.port,
                     access_list_id: "0",
                     certificate_id: "new",
                     meta: {


### PR DESCRIPTION
This update should change the server proxying from the first port to the port with `is_default` set to true.